### PR TITLE
add hackney (depends on idna)

### DIFF
--- a/packages/hackney.exs
+++ b/packages/hackney.exs
@@ -1,0 +1,59 @@
+defmodule Hackney.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :hackney,
+     version: "0.13.0",
+     description: description,
+     package: package,
+     deps: deps,
+     fetch: fetch]
+  end
+
+  defp description do
+    """
+    HTTP client library in Erlang
+    """
+  end
+
+  defp deps do
+    [
+      {:idna, "0.11.2"},
+    ]
+  end
+
+  defp package do
+    [contributors:
+      ["Benoit Chesneau",
+       "Adam Rutkowski",
+       "ILYA Khlopotov",
+       "Leo Lou",
+       "Tristan Sloughter",
+       "Erik Timan",
+       "Bip Thelin",
+       "José Valim",
+       "Дамјан Георгиевски",
+       "Alexander Zhuravlev",
+       "Anthony Grimes",
+       "Bob Ippolito",
+       "Mahesh Paolini-Subramanya",
+       "Jesse Gumm",
+       "Daniel White",
+       "Chris Andrews",
+       "Alexey Aniskin",
+       "Yuki Ito",
+       "Yuriy Bogdanov",
+       "Ben Murphy",
+       "Richard Jones",
+      ],
+    licenses: ["Apache 2.0"],
+    links: %{"GitHub" => "https://github.com/benoitc/hackney"},
+    files: ["src", "include", "README.md", "LICENSE", "Makefile", "rebar.config" ]]
+  end
+
+  defp fetch do
+    [scm: :git,
+     url: "git://github.com/benoitc/hackney.git",
+     tag: "0.13.0"]
+  end
+end


### PR DESCRIPTION
Not tested. Hackney is a dependency of httpoison.

This depends on idna. See other PR.
