### PR TITLE
use IDNA version 1.0.1 for packages idna and hackney

### DIFF
--- a/packages/hackney.exs
+++ b/packages/hackney.exs
@@ -18,7 +18,7 @@ defmodule Hackney.Mixfile do
 
   defp deps do
     [
-      {:idna, "0.11.2"},
+      {:idna, "1.0.1"},
     ]
   end
 

--- a/packages/idna.exs
+++ b/packages/idna.exs
@@ -3,7 +3,7 @@ defmodule Idna.Mixfile do
 
   def project do
     [app: :idna,
-     version: "0.11.2",
+     version: "1.0.1",
      description: description,
      package: package,
      fetch: fetch]
@@ -29,6 +29,6 @@ defmodule Idna.Mixfile do
   defp fetch do
     [scm: :git,
      url: "git://github.com/benoitc/erlang-idna.git",
-     tag: "hackney-0.11.2"]
+     tag: "1.0.1"]
   end
 end


### PR DESCRIPTION
@edgurgel pointed out in discussion in PR #4 that idna version was wrong. This fixes it.

Now these hackney and idna package files look OK to me. But I have not tested them.

![test](http://jerodsanto.net/drop/test-in-production.png)
