### PR TITLE
Update hackney to 0.14.1

### DIFF
--- a/packages/hackney.exs
+++ b/packages/hackney.exs
@@ -3,7 +3,7 @@ defmodule Hackney.Mixfile do
 
   def project do
     [app: :hackney,
-     version: "0.14.0",
+     version: "0.14.1",
      description: description,
      package: package,
      deps: deps,
@@ -54,6 +54,6 @@ defmodule Hackney.Mixfile do
   defp fetch do
     [scm: :git,
      url: "git://github.com/benoitc/hackney.git",
-     tag: "0.14.0"]
+     tag: "0.14.1"]
   end
 end


### PR DESCRIPTION
Update hackney to last release: https://github.com/benoitc/hackney/releases/tag/0.14.1
