### PR TITLE
Add lhttpc

### DIFF
--- a/packages/lhttpc.exs
+++ b/packages/lhttpc.exs
@@ -1,0 +1,26 @@
+defmodule LHttpC.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :lhttpc,
+     version: "1.3.0",
+     description: description,
+     package: package,
+     deps: deps]
+  end
+
+  defp deps do
+    []
+  end
+
+  defp description do
+    "Lightweight HTTP/1.1 client"
+  end
+
+  defp package do
+    [files: ~w(src include test doc util rebar.config CHANGELOG LICENCE README),
+     contributors: ["Erlang Training and Consulting Ltd."],
+     licenses: ["BSD"],
+     links: %{"GitHub" => "https://github.com/talko/lhttpc"}]
+   end
+end


### PR DESCRIPTION
The [erlcloud](https://github.com/gleber/erlcloud/) repository needs this package as a dependency (i.e., the next step will be to add an erlcloud package).  The main repository at the esl user isn't being actively maintained, so erlcloud depends on the talko lhttpc repository (many other forks exist that remain unmerged).  Right now, it appears best to move forward with the talko fork, since none are clearly better (also, some have diverged in significant ways) and erlcloud is an important repository.  Then the [cloudi_core](https://hex.pm/packages/cloudi_core) package will depend on the erlcloud package after the erlcloud package has been added.
