### PR TITLE
Add erlcloud

### DIFF
--- a/packages/erlcloud.exs
+++ b/packages/erlcloud.exs
@@ -1,0 +1,36 @@
+defmodule ErlCloud.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :erlcloud,
+     version: "0.9.0",
+     language: :erlang,
+     description: description,
+     package: package,
+     deps: deps,
+     fetch: fetch]
+  end
+
+  defp deps do
+    [{:jsx, "~> 2.1.1"},
+     {:lhttpc, "~> 1.3.0"},
+     {:meck, "~> 0.8.2"}]
+  end
+
+  defp description do
+    "Cloud Computing library for erlang"
+  end
+
+  defp package do
+    [files: ~w(src include rebar.config rebar.config.script README.md COPYRIGHT),
+     contributors: ["Gleb Peregud"],
+     licenses: ["MIT"],
+     links: %{"GitHub" => "https://github.com/gleber/erlcloud"}]
+   end
+
+  defp fetch do
+    [scm: :git,
+     url: "https://github.com/gleber/erlcloud.git",
+     tag: "v0.9.0"]
+  end
+end


### PR DESCRIPTION
This didn't seem to compile erlcloud when I tried to test it and I am wondering if it is not running the rebar.config.script file.  Can you check this to see if it is ok?  If it isn't, perhaps a fork should be added to avoid the need to use a rebar.config.script file.  The erlcloud repository is a common dependency for client usage of Amazon EC2, S3, SQS, SimpleDB, Mechanical Turk, ELB.  I am adding it for the [cloudi_core](https://hex.pm/packages/cloudi_core) package, since cloudi_core depends on erlcloud for ec2 node discovery.
