### PR TITLE
Update erlcloud version.

### DIFF
--- a/packages/erlcloud.exs
+++ b/packages/erlcloud.exs
@@ -3,7 +3,7 @@ defmodule ErlCloud.Mixfile do
 
   def project do
     [app: :erlcloud,
-     version: "0.9.1",
+     version: "0.9.2-rc.1",
      language: :erlang,
      description: description,
      package: package,
@@ -31,6 +31,6 @@ defmodule ErlCloud.Mixfile do
   defp fetch do
     [scm: :git,
      url: "https://github.com/gleber/erlcloud.git",
-     tag: "v0.9.1"]
+     ref: "596cbcde53b84f78d76e7427573833daa9201c79"]
   end
 end


### PR DESCRIPTION
This is a dependency for nodefinder.  The lhttpc usage was added which changed the errors returned.  The new changes allow httpc to be used as before or any other http client.  The erlcloud repo isn't often tagged and changes often, so I wanted to use a ref for now with a -rc.# version until a new tag is created after the recent changes in the erlcloud repository are tested.
