### PR TITLE
relax constraints on erlcloud's dependencies

### DIFF
--- a/packages/erlcloud.exs
+++ b/packages/erlcloud.exs
@@ -12,8 +12,8 @@ defmodule ErlCloud.Mixfile do
   end
 
   defp deps do
-    [{:jsx, "~> 2.1.1"},
-     {:lhttpc, "~> 1.3.0"},
+    [{:jsx, "~> 2.1"},
+     {:lhttpc, "~> 1.3"},
      {:meck, "~> 0.8.2"}]
   end
 


### PR DESCRIPTION
Both `jsx` and `lhttpc` have hit their 1.0 release which, according to section 7 of [SemVer](http://semver.org/), means it should be safe to pessimistically lock to their last known working minor version.

The erlcloud rebar config itself suggests that erlcloud works with the latest head of `jsx` and `lhttpc`, so this should be reasonably safe.