### PR TITLE
Add mochiweb

### DIFF
--- a/packages/mochiweb.exs
+++ b/packages/mochiweb.exs
@@ -1,0 +1,36 @@
+defmodule Mochiweb.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :mochiweb,
+     version: "2.12.2",
+
+     description: description,
+     package: package,
+     fetch: fetch,
+     deps: deps]
+  end
+
+  defp description do
+    """
+    MochiWeb is an Erlang library for building lightweight HTTP servers.
+    """
+  end
+
+  defp deps do
+    []
+  end
+
+  defp package do
+    [contributors: ["Mochi Media, Inc.", "Bob Ippolito"],
+     licenses: ["MIT"],
+     links: %{"GitHub" => "https://github.com/mochi/mochiweb"},
+     files: ["src", "include", "README", "LICENSE", "CHANGES.md", "rebar.config", "Makefile"]]
+  end
+
+  defp fetch do
+    [scm: :git,
+     url: "git@github.com:mochi/mochiweb.git",
+     tag: "2.12.2"]
+  end
+end

--- a/packages/mochiweb.exs
+++ b/packages/mochiweb.exs
@@ -31,6 +31,6 @@ defmodule Mochiweb.Mixfile do
   defp fetch do
     [scm: :git,
      url: "git@github.com:mochi/mochiweb.git",
-     tag: "2.12.2"]
+     tag: "v2.12.2"]
   end
 end


### PR DESCRIPTION
This PR adds the [MochiWeb](https://github.com/mochi/mochiweb) library. MochiWeb is an Erlang library for building lightweight HTTP servers. It also has a HTML parser built in.

I want to include this package because I need to use the HTML parser for my Elixir package called [Floki](https://github.com/philss/floki). Currently I am embedding the mochiweb modules into the Floki codebase.

I'm not sure if I should include the "[support](https://github.com/mochi/mochiweb/tree/master/support)" path to the `files` list.

This PR is related to https://github.com/philss/floki/issues/5.