### PR TITLE
Bump hackney to 1.3.0

### DIFF
--- a/packages/hackney.exs
+++ b/packages/hackney.exs
@@ -3,7 +3,7 @@ defmodule Hackney.Mixfile do
 
   def project do
     [app: :hackney,
-     version: "1.2.0",
+     version: "1.3.0",
      description: description,
      package: package,
      deps: deps,
@@ -55,6 +55,6 @@ defmodule Hackney.Mixfile do
   defp fetch do
     [scm: :git,
      url: "git://github.com/benoitc/hackney.git",
-     tag: "1.2.0"]
+     tag: "1.3.0"]
   end
 end


### PR DESCRIPTION
[1.3.0](https://github.com/benoitc/hackney/releases/tag/1.3.0) was released 4 days ago 